### PR TITLE
.NET Framework 4.5 tests and fixes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,10 +1,10 @@
 <Project>
     <PropertyGroup>
         <SolutionDir Condition="'$(SolutionDir)'==''">$(MSBuildThisFileDirectory)</SolutionDir>
-        <Version>1.4.5-1</Version>
+        <Version>1.4.5.1</Version>
     </PropertyGroup>
 
-    <Target Name="UpdatePackageCacheForDependencies" BeforeTargets="Restore" Condition="@(NuPkgRef->Count())!=0">
+    <Target Name="UpdatePackageCacheForDependencies" BeforeTargets="Restore;Build" Condition="'@(NuPkgRef->Count())'!='0'">
         <ItemGroup>
             <NuPkgRef Update="**">
                 <Id>$([System.Text.RegularExpressions.Regex]::Replace('%(NuPkgRef.Filename)', '^(.*?)\.(?:\.?[0-9]+){3,}(?:[-a-z]+)?$', '$1'))</Id>
@@ -14,14 +14,12 @@
                 <LowerCaseId>$([System.String]::Copy('%(NuPkgRef.Id)').ToLowerInvariant())</LowerCaseId>
             </NuPkgRef>
         </ItemGroup>
-
         <Message Importance="high" Text="Updating package cache..."/>
         <Message Importance="high" Text="%(NuPkgRef.Id) %(NuPkgRef.Version)"/>
-        <RemoveDir Directories="$(NuGetPackageRoot)\%(NuPkgRef.LowerCaseId)\%(NuPkgRef.Version)\"/>
-        <Unzip
-            SourceFiles="%(NuPkgRef.Identity)"
-            DestinationFolder="$(NuGetPackageRoot)\%(NuPkgRef.LowerCaseId)\%(NuPkgRef.Version)\"
-        />
+        <Unzip SourceFiles="%(NuPkgRef.Identity)"
+               DestinationFolder="$(NuGetPackageRoot)%(NuPkgRef.LowerCaseId)\%(NuPkgRef.Version)\"
+               SkipUnchangedFiles="true">
+        </Unzip>
     </Target>
 
     <PropertyGroup>

--- a/ImpromptuNinjas.ZStd.Tests/BindingTests.Frame.cs
+++ b/ImpromptuNinjas.ZStd.Tests/BindingTests.Frame.cs
@@ -41,7 +41,7 @@ namespace ImpromptuNinjas.ZStd.Tests {
 
       cCtx.UseDictionary(cDict);
 
-      var compressBufferSize = CCtx.GetUpperBound((UIntPtr) sample.Length);
+      var compressBufferSize = CCtx.GetUpperBound((UIntPtr) sample.Length).ToUInt32();
 
       var compressBuffer = new byte[compressBufferSize];
 

--- a/ImpromptuNinjas.ZStd.Tests/BindingTests.Stream.cs
+++ b/ImpromptuNinjas.ZStd.Tests/BindingTests.Stream.cs
@@ -42,7 +42,7 @@ namespace ImpromptuNinjas.ZStd.Tests {
 
       cCtx.UseDictionary(cDict);
 
-      var compressBufferSize = CCtx.GetUpperBound((UIntPtr) sample.Length);
+      var compressBufferSize = CCtx.GetUpperBound((UIntPtr) sample.Length).ToUInt32();
 
       var compressBuffer = new byte[compressBufferSize];
 

--- a/ImpromptuNinjas.ZStd.Tests/ImpromptuNinjas.ZStd.Tests.NetCore31.csproj
+++ b/ImpromptuNinjas.ZStd.Tests/ImpromptuNinjas.ZStd.Tests.NetCore31.csproj
@@ -12,9 +12,9 @@
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="5.10.3" />
         <PackageReference Include="JetBrains.Annotations" Version="2020.1.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
         <PackageReference Include="NUnit" Version="3.12.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
+        <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="ImpromptuNinjas.ZStd" Version="[$(Version)]">
@@ -35,17 +35,20 @@
         <None Include="..\nuget.config">
             <Link>nuget.config</Link>
         </None>
-        <None Remove="NetStandard*\**" />
     </ItemGroup>
     <ItemGroup>
         <Compile Update="**\*.*.cs">
             <WouldDependOn>$([System.Text.RegularExpressions.Regex]::Replace('%(Filename)', '^(.*?)\..*$', '$1.cs'))</WouldDependOn>
             <DependentUpon Condition="'%(DependentUpon)' == '' And '%(WouldDependOn)' != '%(Filename)'">%(WouldDependOn)</DependentUpon>
         </Compile>
-        <Compile Remove="NetStandard*\**" />
     </ItemGroup>
     <ItemGroup>
+        <None Remove="NetStandard*\**" />
+        <None Remove="NetFramework*\**" />
+        <Compile Remove="NetStandard*\**" />
+        <Compile Remove="NetFramework*\**" />
         <EmbeddedResource Remove="NetStandard*\**" />
+        <EmbeddedResource Remove="NetFramework*\**" />
     </ItemGroup>
     <ItemGroup>
         <NuPkgRef Include="..\*.nupkg">

--- a/ImpromptuNinjas.ZStd.Tests/NetFramework45AnyCpu/ImpromptuNinjas.ZStd.Tests.NetFramework45AnyCpu.csproj
+++ b/ImpromptuNinjas.ZStd.Tests/NetFramework45AnyCpu/ImpromptuNinjas.ZStd.Tests.NetFramework45AnyCpu.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netcoreapp$(NETCoreAppMaximumVersion)</TargetFramework>
+        <TargetFramework>net45</TargetFramework>
     </PropertyGroup>
     <PropertyGroup>
         <IsPackable>false</IsPackable>
@@ -8,6 +8,8 @@
         <LangVersion>8</LangVersion>
         <RootNamespace>ImpromptuNinjas.ZStd.Tests</RootNamespace>
         <IncludeSourceRevisionInInformationalVersion>False</IncludeSourceRevisionInInformationalVersion>
+        <RuntimeIdentifier>win</RuntimeIdentifier>
+        <PlatformTarget>AnyCPU</PlatformTarget>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="5.10.3" />
@@ -15,6 +17,12 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
         <PackageReference Include="NUnit" Version="3.12.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+        <PackageReference Include="System.Buffers" Version="4.5.1" />
+        <PackageReference Include="System.Memory" Version="4.5.4" />
+        <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
+        <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
+        <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.3.4" />
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="ImpromptuNinjas.ZStd" Version="[$(Version)]">
@@ -22,7 +30,7 @@
             <GeneratePathProperty>true</GeneratePathProperty>
         </PackageReference>
         <Reference Include="ImpromptuNinjas.ZStd.dll">
-            <HintPath>$(PkgImpromptuNinjas_ZStd)\lib\netstandard1.4\ImpromptuNinjas.ZStd.dll</HintPath>
+            <HintPath>$(PkgImpromptuNinjas_ZStd)\lib\net45\ImpromptuNinjas.ZStd.dll</HintPath>
         </Reference>
     </ItemGroup>
     <ItemGroup>

--- a/ImpromptuNinjas.ZStd.Tests/NetFramework45AnyCpu/PlatformTests.cs
+++ b/ImpromptuNinjas.ZStd.Tests/NetFramework45AnyCpu/PlatformTests.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using FluentAssertions;
+#if MSTEST
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+#else
+using NUnit.Framework;
+#endif
+
+namespace ImpromptuNinjas.ZStd.Tests {
+
+  public partial class PlatformTests {
+
+#if MSTEST
+    [TestMethod,UseParameterValues]
+#else
+    [Test]
+#endif
+    public unsafe void TargetFrameworkCheck() {
+      var tf = typeof(ZStdException).Assembly.GetCustomAttribute<TargetFrameworkAttribute>();
+
+      tf?.FrameworkName.Should().Be(".NETFramework,Version=v4.5");
+
+      Console.WriteLine(tf?.FrameworkName);
+    }
+
+  }
+
+}

--- a/ImpromptuNinjas.ZStd.Tests/NetFramework45x64/ImpromptuNinjas.ZStd.Tests.NetFramework45x64.csproj
+++ b/ImpromptuNinjas.ZStd.Tests/NetFramework45x64/ImpromptuNinjas.ZStd.Tests.NetFramework45x64.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netcoreapp$(NETCoreAppMaximumVersion)</TargetFramework>
+        <TargetFramework>net45</TargetFramework>
     </PropertyGroup>
     <PropertyGroup>
         <IsPackable>false</IsPackable>
@@ -8,6 +8,8 @@
         <LangVersion>8</LangVersion>
         <RootNamespace>ImpromptuNinjas.ZStd.Tests</RootNamespace>
         <IncludeSourceRevisionInInformationalVersion>False</IncludeSourceRevisionInInformationalVersion>
+        <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+        <PlatformTarget>x64</PlatformTarget>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="5.10.3" />
@@ -15,6 +17,12 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
         <PackageReference Include="NUnit" Version="3.12.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+        <PackageReference Include="System.Buffers" Version="4.5.1" />
+        <PackageReference Include="System.Memory" Version="4.5.4" />
+        <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
+        <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
+        <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.3.4" />
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="ImpromptuNinjas.ZStd" Version="[$(Version)]">
@@ -22,7 +30,7 @@
             <GeneratePathProperty>true</GeneratePathProperty>
         </PackageReference>
         <Reference Include="ImpromptuNinjas.ZStd.dll">
-            <HintPath>$(PkgImpromptuNinjas_ZStd)\lib\netstandard1.4\ImpromptuNinjas.ZStd.dll</HintPath>
+            <HintPath>$(PkgImpromptuNinjas_ZStd)\lib\net45\ImpromptuNinjas.ZStd.dll</HintPath>
         </Reference>
     </ItemGroup>
     <ItemGroup>

--- a/ImpromptuNinjas.ZStd.Tests/NetFramework45x64/PlatformTests.cs
+++ b/ImpromptuNinjas.ZStd.Tests/NetFramework45x64/PlatformTests.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using FluentAssertions;
+#if MSTEST
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+#else
+using NUnit.Framework;
+#endif
+
+namespace ImpromptuNinjas.ZStd.Tests {
+
+  public partial class PlatformTests {
+
+#if MSTEST
+    [TestMethod,UseParameterValues]
+#else
+    [Test]
+#endif
+    public unsafe void TargetFrameworkCheck() {
+      sizeof(void*).Should().Be(8);
+
+      var tf = typeof(ZStdException).Assembly.GetCustomAttribute<TargetFrameworkAttribute>();
+
+      tf?.FrameworkName.Should().Be(".NETFramework,Version=v4.5");
+
+      Console.WriteLine(tf?.FrameworkName);
+    }
+
+  }
+
+}

--- a/ImpromptuNinjas.ZStd.Tests/NetFramework45x86/ImpromptuNinjas.ZStd.Tests.NetFramework45x86.csproj
+++ b/ImpromptuNinjas.ZStd.Tests/NetFramework45x86/ImpromptuNinjas.ZStd.Tests.NetFramework45x86.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netcoreapp$(NETCoreAppMaximumVersion)</TargetFramework>
+        <TargetFramework>net45</TargetFramework>
     </PropertyGroup>
     <PropertyGroup>
         <IsPackable>false</IsPackable>
@@ -8,6 +8,8 @@
         <LangVersion>8</LangVersion>
         <RootNamespace>ImpromptuNinjas.ZStd.Tests</RootNamespace>
         <IncludeSourceRevisionInInformationalVersion>False</IncludeSourceRevisionInInformationalVersion>
+        <RuntimeIdentifier>win-x86</RuntimeIdentifier>
+        <PlatformTarget>x86</PlatformTarget>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="5.10.3" />
@@ -15,6 +17,12 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
         <PackageReference Include="NUnit" Version="3.12.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+        <PackageReference Include="System.Buffers" Version="4.5.1" />
+        <PackageReference Include="System.Memory" Version="4.5.4" />
+        <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
+        <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
+        <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.3.4" />
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="ImpromptuNinjas.ZStd" Version="[$(Version)]">
@@ -22,7 +30,7 @@
             <GeneratePathProperty>true</GeneratePathProperty>
         </PackageReference>
         <Reference Include="ImpromptuNinjas.ZStd.dll">
-            <HintPath>$(PkgImpromptuNinjas_ZStd)\lib\netstandard1.4\ImpromptuNinjas.ZStd.dll</HintPath>
+            <HintPath>$(PkgImpromptuNinjas_ZStd)\lib\net45\ImpromptuNinjas.ZStd.dll</HintPath>
         </Reference>
     </ItemGroup>
     <ItemGroup>

--- a/ImpromptuNinjas.ZStd.Tests/NetFramework45x86/PlatformTests.cs
+++ b/ImpromptuNinjas.ZStd.Tests/NetFramework45x86/PlatformTests.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using FluentAssertions;
+#if MSTEST
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+#else
+using NUnit.Framework;
+#endif
+
+namespace ImpromptuNinjas.ZStd.Tests {
+
+  public partial class PlatformTests {
+
+#if MSTEST
+    [TestMethod,UseParameterValues]
+#else
+    [Test]
+#endif
+    public unsafe void TargetFrameworkCheck() {
+      sizeof(void*).Should().Be(4);
+
+      var tf = typeof(ZStdException).Assembly.GetCustomAttribute<TargetFrameworkAttribute>();
+
+      tf?.FrameworkName.Should().Be(".NETFramework,Version=v4.5");
+
+      Console.WriteLine(tf?.FrameworkName);
+    }
+
+  }
+
+}

--- a/ImpromptuNinjas.ZStd.Tests/NetStandard11/ImpromptuNinjas.ZStd.Tests.NetStandard11.csproj
+++ b/ImpromptuNinjas.ZStd.Tests/NetStandard11/ImpromptuNinjas.ZStd.Tests.NetStandard11.csproj
@@ -12,9 +12,9 @@
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="5.10.3" />
         <PackageReference Include="JetBrains.Annotations" Version="2020.1.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
         <PackageReference Include="NUnit" Version="3.12.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
+        <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="ImpromptuNinjas.ZStd" Version="[$(Version)]">

--- a/ImpromptuNinjas.ZStd.Tests/NetStandard20/ImpromptuNinjas.ZStd.Tests.NetStandard20.csproj
+++ b/ImpromptuNinjas.ZStd.Tests/NetStandard20/ImpromptuNinjas.ZStd.Tests.NetStandard20.csproj
@@ -12,9 +12,9 @@
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="5.10.3" />
         <PackageReference Include="JetBrains.Annotations" Version="2020.1.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
         <PackageReference Include="NUnit" Version="3.12.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
+        <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="ImpromptuNinjas.ZStd" Version="[$(Version)]">

--- a/ImpromptuNinjas.ZStd.Tests/NetStandard21/ImpromptuNinjas.ZStd.Tests.NetStandard21.csproj
+++ b/ImpromptuNinjas.ZStd.Tests/NetStandard21/ImpromptuNinjas.ZStd.Tests.NetStandard21.csproj
@@ -12,9 +12,9 @@
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="5.10.3" />
         <PackageReference Include="JetBrains.Annotations" Version="2020.1.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
         <PackageReference Include="NUnit" Version="3.12.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
+        <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="ImpromptuNinjas.ZStd" Version="[$(Version)]">

--- a/ImpromptuNinjas.ZStd.Tests/PlatformTests.cs
+++ b/ImpromptuNinjas.ZStd.Tests/PlatformTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
@@ -31,12 +32,18 @@ namespace ImpromptuNinjas.ZStd.Tests {
 
       var tf = zstdAsm.GetCustomAttribute<TargetFrameworkAttribute>();
 
+      var dir = Path.GetDirectoryName(new Uri(zstdAsm.CodeBase!).LocalPath)!;
+
       string commit = null;
-      using (var proc = Process.Start(new ProcessStartInfo("git","rev-parse HEAD") {
-        RedirectStandardOutput = true
+      using (var proc = Process.Start(new ProcessStartInfo("git", "rev-parse HEAD") {
+        RedirectStandardOutput = true,
+        RedirectStandardError = true,
+        UseShellExecute = false,
+        WorkingDirectory = dir
       })) {
         proc?.Start();
         commit = proc?.StandardOutput.ReadToEnd()?.Trim();
+        proc?.StandardError.ReadToEnd().Should().BeNullOrWhiteSpace();
       }
 
       commit.Should().NotBeNullOrEmpty();
@@ -47,7 +54,11 @@ namespace ImpromptuNinjas.ZStd.Tests {
 
       version.Should().NotBeNullOrEmpty();
 
+#if NETFRAMEWORK
+      (version?.Split(new[] {'+'}, 2)[1]).Should().Be(commit);
+#else
       (version?.Split('+', 2)[1]).Should().Be(commit);
+#endif
 
       Console.WriteLine($"Assembly Informational Version: {version}");
 

--- a/ImpromptuNinjas.ZStd/Classes/ZStdCompressor.cs
+++ b/ImpromptuNinjas.ZStd/Classes/ZStdCompressor.cs
@@ -34,7 +34,7 @@ namespace ImpromptuNinjas.ZStd {
     public static int MinimumCompressionLevel
       => _lazyMinimumCompressionLevel ??= Native.ZStd.GetMinCompressionLevel();
 
-    public static ulong GetUpperBound(UIntPtr srcSize)
+    public static UIntPtr GetUpperBound(UIntPtr srcSize)
       => CompressBound(srcSize);
 
     public unsafe ZStdCompressor Clone(ulong pledgedSrcSize = ulong.MaxValue)

--- a/ImpromptuNinjas.ZStd/ImpromptuNinjas.ZStd.csproj
+++ b/ImpromptuNinjas.ZStd/ImpromptuNinjas.ZStd.csproj
@@ -54,7 +54,7 @@
                 <When Condition="$(TargetFramework.EndsWith('2.1'))">
                     <ItemGroup>
                         <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.3.4" />
-                        <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.0" />
+                        <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
                     </ItemGroup>
                 </When>
                 <When Condition="$(TargetFramework.EndsWith('2.0'))">
@@ -81,7 +81,7 @@
                         <PackageReference Include="System.Collections" Version="4.3.0" />
                         <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
                         <PackageReference Include="System.Threading" Version="4.3.0" />
-                        <PackageReference Include="System.Memory" Version="4.5.3" />
+                        <PackageReference Include="System.Memory" Version="4.5.4" />
                     </ItemGroup>
                 </When>
             </Choose>
@@ -93,6 +93,20 @@
             <Pack>True</Pack>
             <PackageCopyToOutput>True</PackageCopyToOutput>
             <PackagePath>runtimes\</PackagePath>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+            <Link>%(Identity)</Link>
+        </Content>
+        <Content Include="runtimes\win-x64\native\libzstd.dll">
+            <Pack>True</Pack>
+            <PackageCopyToOutput>True</PackageCopyToOutput>
+            <PackagePath>runtimes\win\native\net45\libzstd64.dll</PackagePath>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+            <Link>%(Identity)</Link>
+        </Content>
+        <Content Include="runtimes\win-x86\native\libzstd.dll">
+            <Pack>True</Pack>
+            <PackageCopyToOutput>True</PackageCopyToOutput>
+            <PackagePath>runtimes\win\native\net45\libzstd32.dll</PackagePath>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
             <Link>%(Identity)</Link>
         </Content>

--- a/ImpromptuNinjas.ZStd/Native.ZStdCCtx.cs
+++ b/ImpromptuNinjas.ZStd/Native.ZStdCCtx.cs
@@ -109,13 +109,13 @@ namespace ImpromptuNinjas.ZStd {
       }
 
       [MethodImpl(MethodImplOptions.AggressiveInlining)]
-      public static ulong CompressBound(UIntPtr srcSize) {
+      public static UIntPtr CompressBound(UIntPtr srcSize) {
         IL.Push(srcSize);
         IL.Push(ZSTD_compressBound);
         IL.Emit.Tail();
-        IL.Emit.Calli(new StandAloneMethodSig(CallingConvention.Cdecl, typeof(ulong),
+        IL.Emit.Calli(new StandAloneMethodSig(CallingConvention.Cdecl, typeof(UIntPtr),
           typeof(UIntPtr)));
-        return IL.Return<ulong>();
+        return IL.Return<UIntPtr>();
       }
 
       [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/ImpromptuNinjas.ZStd/Structs/CCtx.cs
+++ b/ImpromptuNinjas.ZStd/Structs/CCtx.cs
@@ -19,7 +19,7 @@ namespace ImpromptuNinjas.ZStd {
     public static int GetMinCompressionLevel()
       => Native.ZStd.GetMinCompressionLevel();
 
-    public static ulong GetUpperBound(UIntPtr srcSize)
+    public static UIntPtr GetUpperBound(UIntPtr srcSize)
       => CompressBound(srcSize);
 
   }

--- a/ImpromptuNinjas.ZStd/Utilities/NativeLibrary.cs
+++ b/ImpromptuNinjas.ZStd/Utilities/NativeLibrary.cs
@@ -69,7 +69,11 @@ namespace ImpromptuNinjas.ZStd {
 
         var loaded = Load(libraryName);
         if (loaded == default)
-          throw new DllNotFoundException(libraryName);
+#if NETSTANDARD1_1
+          throw new Exception(libraryName);
+#else
+          throw new InvalidProgramException(libraryName);
+#endif
 
         return loaded;
       }
@@ -81,7 +85,11 @@ namespace ImpromptuNinjas.ZStd {
 
       var loaded = Loader.Load(libraryPath);
       if (loaded == default)
-        throw new DllNotFoundException(libraryPath);
+#if NETSTANDARD1_1
+          throw new InvalidOperationException(libraryPath);
+#else
+          throw new InvalidProgramException(libraryPath);
+#endif
 
       return loaded;
     }

--- a/ZStd.sln
+++ b/ZStd.sln
@@ -12,6 +12,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ImpromptuNinjas.ZStd.Tests.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ImpromptuNinjas.ZStd.Tests.NetStandard21", "ImpromptuNinjas.ZStd.Tests\NetStandard21\ImpromptuNinjas.ZStd.Tests.NetStandard21.csproj", "{F36A8061-E0B1-41FF-AC4C-64208B00D1D4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ImpromptuNinjas.ZStd.Tests.NetFramework45x64", "ImpromptuNinjas.ZStd.Tests\NetFramework45x64\ImpromptuNinjas.ZStd.Tests.NetFramework45x64.csproj", "{8E193A4F-E28E-4747-BEAE-2D9161196AAC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ImpromptuNinjas.ZStd.Tests.NetFramework45x86", "ImpromptuNinjas.ZStd.Tests\NetFramework45x86\ImpromptuNinjas.ZStd.Tests.NetFramework45x86.csproj", "{27D73992-C90A-419E-8C63-A69E1509448E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ImpromptuNinjas.ZStd.Tests.NetFramework45AnyCpu", "ImpromptuNinjas.ZStd.Tests\NetFramework45AnyCpu\ImpromptuNinjas.ZStd.Tests.NetFramework45AnyCpu.csproj", "{CC0C2D16-0BC2-42B2-935C-73C762DE6349}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -42,5 +48,17 @@ Global
 		{F36A8061-E0B1-41FF-AC4C-64208B00D1D4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F36A8061-E0B1-41FF-AC4C-64208B00D1D4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F36A8061-E0B1-41FF-AC4C-64208B00D1D4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8E193A4F-E28E-4747-BEAE-2D9161196AAC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8E193A4F-E28E-4747-BEAE-2D9161196AAC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8E193A4F-E28E-4747-BEAE-2D9161196AAC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8E193A4F-E28E-4747-BEAE-2D9161196AAC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{27D73992-C90A-419E-8C63-A69E1509448E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{27D73992-C90A-419E-8C63-A69E1509448E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{27D73992-C90A-419E-8C63-A69E1509448E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{27D73992-C90A-419E-8C63-A69E1509448E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CC0C2D16-0BC2-42B2-935C-73C762DE6349}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CC0C2D16-0BC2-42B2-935C-73C762DE6349}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CC0C2D16-0BC2-42B2-935C-73C762DE6349}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CC0C2D16-0BC2-42B2-935C-73C762DE6349}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Fix integer overflow in upper bounds on platforms with calls that don't clear the high bits (e.g. cause it's a separate register like edx)

Fix up and add tests for NET v4.5 against AnyCPU, x86 and x64.